### PR TITLE
Configure dependabot for dependencies of blueprint itself

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,15 @@
 version: 2
 updates:
   - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+      time: '12:00'
+    versioning-strategy: increase
+    labels:
+      - 'theme: dependencies'
+
+  - package-ecosystem: 'npm'
     directory: '/generators/angular-audit/resources/'
     schedule:
       interval: 'daily'


### PR DESCRIPTION
I noticed e.g. something like this:

https://github.com/jhipster/generator-jhipster-entity-audit/blob/0ccd253cd363185f71a77ebfadb051a49cb2d626/package.json#L65

So I think, we should also perform updates for the packages of the blueprint itself