### PR TITLE
Get rid of usage of deprecated method from javers

### DIFF
--- a/generators/spring-boot-javers/templates/src/main/java/_package_/web/rest/JaversEntityAuditResource.java.ejs
+++ b/generators/spring-boot-javers/templates/src/main/java/_package_/web/rest/JaversEntityAuditResource.java.ejs
@@ -77,8 +77,7 @@ public class JaversEntityAuditResource {
 
         Class entityTypeToFetch = Class.forName("<%=packageName%>.domain." + entityType);
         QueryBuilder jqlQuery = QueryBuilder.byClass(entityTypeToFetch)
-                                            .limit(limit)
-                                            .withNewObjectChanges(true);
+                                            .limit(limit);
 
         List<CdoSnapshot> snapshots =  javers.findSnapshots(jqlQuery.build());
 
@@ -116,8 +115,7 @@ public class JaversEntityAuditResource {
 
         QueryBuilder jqlQuery = QueryBuilder.byInstanceId(entityId, entityTypeToFetch)
                                            .limit(1)
-                                           .withVersion(commitVersion - 1)
-                                           .withNewObjectChanges(true);
+                                           .withVersion(commitVersion - 1);
 
         EntityAuditEvent prev = EntityAuditEvent.fromJaversSnapshot(javers.findSnapshots(jqlQuery.build()).get(0));
 


### PR DESCRIPTION
as withNewObjectChanges is deprecated and has no effect


See https://javadoc.io/doc/org.javers/javers-core/6.2.0/org/javers/repository/jql/QueryBuilder.html#withNewObjectChanges(boolean)
and https://javadoc.io/doc/org.javers/javers-core/6.2.0/org/javers/core/JaversBuilder.html#withInitialChanges(boolean) which anyway seemingly defaults to the desired behaviour...