### PR TITLE
Fixed issue of failing duplicate line ending removal

### DIFF
--- a/generators/spring-boot-javers/__snapshots__/generator.spec.js.snap
+++ b/generators/spring-boot-javers/__snapshots__/generator.spec.js.snap
@@ -94,8 +94,8 @@ exports[`SubGenerator spring-boot-javers of entity-audit JHipster blueprint > sh
     "contents": "package com.mycompany.myapp.config.audit;
 
 public enum AuditedEntity {
-    CAMELCASE(com.mycompany.myapp.domain.CamelCase.class, "domain.CamelCase"),
-    CUSTOM_WITHENTITYPACKAGE(com.mycompany.myapp.custom.domain.WithEntityPackage.class, "custom.domain.WithEntityPackage");
+    CAMELCASE( com.mycompany.myapp.domain.CamelCase.class, "domain.CamelCase" ),
+    CUSTOM_WITHENTITYPACKAGE( com.mycompany.myapp.custom.domain.WithEntityPackage.class, "custom.domain.WithEntityPackage" );
     // jhipster-needle-add-audited-entities - JHipster will add entities to this enum
 
     private final Class<?> entityClass;

--- a/generators/spring-boot-javers/generator.js
+++ b/generators/spring-boot-javers/generator.js
@@ -22,7 +22,7 @@ export default class extends BaseApplicationGenerator {
       },
       async addNeedle({ application, source }) {
         source.addEntityToAuditedEntityEnum = ({ entityAuditEnumValue, entityAbsoluteClass, entityAuditEventType }) => {
-          const enumValueDeclaration = `${entityAuditEnumValue}(${entityAbsoluteClass}.class, "${entityAuditEventType}")`;
+          const enumValueDeclaration = `${entityAuditEnumValue}( ${entityAbsoluteClass}.class, "${entityAuditEventType}" )`;
           this.editFile(
             `${application.javaPackageSrcDir}config/audit/AuditedEntity.java`,
             createNeedleCallback({
@@ -39,7 +39,7 @@ export default class extends BaseApplicationGenerator {
                 const needleIndex = content.indexOf('    // jhipster-needle-add-audited-entities');
                 let beforeContent = content.substring(0, needleIndex);
                 // Drop extra line ending if it exists, can be caused by prettier formatting
-                beforeContent = beforeContent.endsWith('/n/n') ? beforeContent.slice(0, -1) : beforeContent;
+                beforeContent = beforeContent.endsWith('\n\n') ? beforeContent.slice(0, -1) : beforeContent;
                 const afterContent = content.substring(needleIndex);
 
                 if (!beforeContent.includes(needleValuePrefix) || !beforeContent.endsWith(needleValueSuffix)) {


### PR DESCRIPTION
and therefore failing jhipster jdl command. Also avoid prettier formatting to cause producing duplicate entries in the class, if one entry is split upon multiple lines.

The standard built-in prettier of generator-jhipster formats very long lines (when entity names are long) into multiple lines. Then detection of the existence of that entry in that file failed before, so this blueprint just added again with every jhipster jdl run.