### PR TITLE
Actually show the last changes instead of running into an error

### DIFF
--- a/generators/spring-boot-javers/templates/src/main/java/_package_/web/rest/JaversEntityAuditResource.java.ejs
+++ b/generators/spring-boot-javers/templates/src/main/java/_package_/web/rest/JaversEntityAuditResource.java.ejs
@@ -93,7 +93,7 @@ public class JaversEntityAuditResource {
 
         snapshots.forEach(snapshot -> {
            EntityAuditEvent event = EntityAuditEvent.fromJaversSnapshot(snapshot);
-           event.setEntityType(auditedEntity.getEventEntityType());
+           event.setEntityType(auditedEntity.name());
            auditEvents.add(event);
         });
 


### PR DESCRIPTION
At the moment, when trying to view the details of an Audit entry, the corresponding request runs into a 400 Bad Request, with a response like this:

```
{
    "type": "about:blank",
    "title": "Bad Request",
    "status": 400,
    "detail": "Failed to convert 'qualifiedName' with value: 'domain.MyEntityName'",
    "instance": "/api/audits/entity/changes/version/previous"
}
```

This is because Spring by default wouldn't know how to deserialize the String representation of 'domain.MyEntityName' into the AuditedEntity.MYENTITYNAME.

This is because here, the entityType is set to that String value 'domain.MyEntityName':

https://github.com/jhipster/generator-jhipster-entity-audit/blob/c25a9848cf30417021878ad284d94d492441e980/generators/spring-boot-javers/templates/src/main/java/_package_/web/rest/JaversEntityAuditResource.java.ejs#L94-L98

But in this method parameter, we directly expect the enum:
https://github.com/jhipster/generator-jhipster-entity-audit/blob/c25a9848cf30417021878ad284d94d492441e980/generators/spring-boot-javers/templates/src/main/java/_package_/web/rest/JaversEntityAuditResource.java.ejs#L116-L118

Of course, we could implement a custom deserialization for that enum, but I think, just passing the enum name() in the first method, so that the second one can actually deserialize it, is definetely easiest.
